### PR TITLE
Add an API endpoint to retrieve an environment catalog

### DIFF
--- a/lib/puppet/application/app.rb
+++ b/lib/puppet/application/app.rb
@@ -220,7 +220,7 @@ end
 class AppCompiler
   attr_reader :applications, :definitions, :resources
 
-  def initialize
+  def initialize(env)
     @@find_visitor ||= Puppet::Pops::Visitor.new(self, "find", 0, 0)
     @@eval_visitor ||= Puppet::Pops::Visitor.new(self, "eval", 1, 1)
     @@expand_visitor ||= Puppet::Pops::Visitor.new(self, "expand", 2, 2)
@@ -231,6 +231,8 @@ class AppCompiler
                              # (ResourceExpression), in the order in which
                              # they were parsed
     @locator = nil           # Will be filled in find_Program
+
+    @environment = env
 
     # All this setup is only here to use EvaluatingParser and Scope
     @parser  = Puppet::Pops::Parser::EvaluatingParser.new
@@ -485,7 +487,7 @@ class AppCompiler
     node = Puppet::Node.new(node_name)
     # @todo lutter 2014-11-17: don't hardcode the environment in which we
     # are working
-    node.environment = Puppet::Node::Environment.create(:development, [])
+    node.environment = Puppet::Node::Environment.create(@environment, [])
     compiler = Puppet::Parser::Compiler.new(node)
     @scope = Puppet::Parser::Scope.new(compiler)
     @scope.source = Puppet::Resource::Type.new(:node, 'node.example.com')
@@ -612,7 +614,7 @@ Copyright (c) 2014 Puppet Labs, LLC Licensed under the Apache 2.0 License
     # puts Puppet::Pops::Model::ModelTreeDumper.new.dump(ast)
 
     # Walk the AST and extract application definitions
-    compiler = AppCompiler.new
+    compiler = AppCompiler.new(:development)
     compiler.find(ast.current)
 
     compiler.eval

--- a/lib/puppet/network/http/api/v2.rb
+++ b/lib/puppet/network/http/api/v2.rb
@@ -1,11 +1,12 @@
 module Puppet::Network::HTTP::API::V2
+  require 'puppet/network/http/api/v2/environment'
   require 'puppet/network/http/api/v2/environments'
   require 'puppet/network/http/api/v2/authorization'
 
   def self.routes
     path(%r{^/v2\.0}).
       get(Authorization.new).
-      chain(ENVIRONMENTS, NOT_FOUND)
+      chain(ENVIRONMENTS, ENVIRONMENT, NOT_FOUND)
   end
 
   private
@@ -28,5 +29,9 @@ module Puppet::Network::HTTP::API::V2
 
   ENVIRONMENTS = path(%r{^/environments$}).get(provide do
     Environments.new(Puppet.lookup(:environments))
+  end)
+
+  ENVIRONMENT = path(%r{^/environment/[^/]+$}).get(provide do
+    Environment.new
   end)
 end

--- a/lib/puppet/network/http/api/v2/environment.rb
+++ b/lib/puppet/network/http/api/v2/environment.rb
@@ -1,0 +1,56 @@
+require 'json'
+
+class Puppet::Network::HTTP::API::V2::Environment
+  def call(request, response)
+    require 'puppet/application/app'
+    Puppet[:parser] = 'future'
+
+    env_name = request.routing_path.split('/').last
+    env = Puppet.lookup(:environments).get(env_name)
+
+    if File.directory?(env.manifest)
+      manifests = Puppet::FileSystem::PathPattern.absolute(File.join(env.manifest, '**/*.pp')).glob
+    else
+      manifests = [env.manifest]
+    end
+
+    compiler = AppCompiler.new(env.name)
+
+    parser = Puppet::Pops::Parser::Parser.new
+    manifests.each do |manifest|
+      ast = parser.parse_file(manifest)
+      compiler.find(ast.current)
+    end
+
+    compiler.eval
+
+    env_graph = {:environment => env.name, :applications => {}}
+    compiler.applications.each do |app|
+      app_components = {}
+      app.mapping.components.each do |comp|
+        app_components[comp.ref] = {:produces => comp.produces.map(&:ref), :consumes => comp.consumes.map(&:ref)}
+      end
+      app.mapping.components_by_node.each do |node, comps|
+        comps.each do |comp|
+          app_components[comp.ref][:node] = node
+        end
+      end
+      env_graph[:applications][app.ref] = app_components
+    end
+
+    response.respond_with(200, "application/json", JSON.dump(env_graph))
+  end
+
+  private
+
+  def timeout(env)
+    ttl = @env_loader.get_conf(env.name).environment_timeout
+    if ttl == 1.0 / 0.0 # INFINITY
+      "unlimited"
+    else
+      ttl
+    end
+  end
+
+end
+


### PR DESCRIPTION
This reuses the AppCompiler from the 'app' application, but slightly modifies
it to take the environment as an argument.

This will parse all the manifests in $manifest, and return an environment
catalog with all the applications.