### PR TITLE
Properly collect capabilities when consuming an array

### DIFF
--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -378,7 +378,7 @@ class Puppet::Resource::Type
   def find_capabilities(resource, scope, param, value)
     # @todo lutter 2014-11-13: type switching, really ?
     if value.is_a?(Array)
-      value.each { |x| find_capabilities(resource, scope, param, x) }
+      value.flat_map { |x| find_capabilities(resource, scope, param, x) }
     elsif value.is_a?(Puppet::Resource)
       find_capability(resource, scope, param, value)
     else


### PR DESCRIPTION
Previously this was fetching the capabilities and adding them to the catalog,
but then throwing them away and returning the original resource refs (without
parameters) which got set as a param of the resource. That meant that looking
up params on those capability resources from within templates would fail,
since they weren't set. Looking up params from within puppet code still
worked, presumably because the resource refs were automatically resolved to
the catalog version of the resource.

We now collect the full versions of the resources and set those, rather than
throwing them away.