### PR TITLE
(APPMGMT-144) Handle unknown environment when fetching catalog

### DIFF
--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -6,6 +6,10 @@ class Puppet::Network::HTTP::API::Master::V3::Environment
     env_name = request.routing_path.split('/').last
     env = Puppet.lookup(:environments).get(env_name)
 
+    if env.nil?
+      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("#{env_name} is not a known environment", Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
+    end
+
     catalog = Puppet::Parser::EnvironmentCompiler.compile(env).to_resource
 
     env_graph = {:environment => env.name, :applications => {}}


### PR DESCRIPTION
Previously, if the user requested the environment catalog for an unknown
environment, they would see a NoMethodError due to environment being
nil. Now we explicitly handle this case and properly return 404 if the
environment doesn't exist.