### PR TITLE
[RFC] (PUP-4903)

### DIFF
--- a/lib/puppet/indirector/resource_type/parser.rb
+++ b/lib/puppet/indirector/resource_type/parser.rb
@@ -27,7 +27,7 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
       krt = resource_types_in(request.environment)
 
       # This is a bit ugly.
-      [:hostclass, :definition, :node].each do |type|
+      [:hostclass, :definition, :application, :node].each do |type|
         # We have to us 'find_<type>' here because it will
         # load any missing types from disk, whereas the plain
         # '<type>' method only returns from memory.
@@ -66,14 +66,16 @@ class Puppet::Indirector::ResourceType::Parser < Puppet::Indirector::Code
             krt.hostclasses.values
           when "defined_type"
             krt.definitions.values
+          when "application"
+            krt.applications.values
           when "node"
             krt.nodes.values
           when nil
-            result_candidates = [krt.hostclasses.values, krt.definitions.values, krt.nodes.values]
+            result_candidates = [krt.hostclasses.values, krt.definitions.values, krt.applications.values, krt.nodes.values]
           else
             raise ArgumentError, "Unrecognized kind filter: " +
                       "'#{request.options[:kind]}', expected one " +
-                      " of 'class', 'defined_type', or 'node'."
+                      " of 'class', 'defined_type', 'application', or 'node'."
         end
 
       result = result_candidates.flatten.reject { |t| t.name == "" }

--- a/lib/puppet/network/http/api/master/v3.rb
+++ b/lib/puppet/network/http/api/master/v3.rb
@@ -1,6 +1,7 @@
 class Puppet::Network::HTTP::API::Master::V3
   require 'puppet/network/http/api/master/v3/authorization'
   require 'puppet/network/http/api/master/v3/environments'
+  require 'puppet/network/http/api/master/v3/environment'
   require 'puppet/network/http/api/indirected_routes'
 
   AUTHZ = Authorization.new
@@ -14,9 +15,14 @@ class Puppet::Network::HTTP::API::Master::V3
     Environments.new(Puppet.lookup(:environments))
   end)
 
+  ENVIRONMENT = Puppet::Network::HTTP::Route.
+      path(%r{/environment/[^/]+$}).get(AUTHZ.wrap do
+    Environment.new
+  end)
+
   def self.routes
     Puppet::Network::HTTP::Route.path(%r{v3}).
         any.
-        chain(ENVIRONMENTS, INDIRECTED)
+        chain(ENVIRONMENTS, ENVIRONMENT, INDIRECTED)
   end
 end

--- a/lib/puppet/network/http/api/master/v3/environment.rb
+++ b/lib/puppet/network/http/api/master/v3/environment.rb
@@ -1,0 +1,56 @@
+require 'json'
+require 'puppet/parser/environment_compiler'
+
+class Puppet::Network::HTTP::API::Master::V3::Environment
+  def call(request, response)
+    env_name = request.routing_path.split('/').last
+    env = Puppet.lookup(:environments).get(env_name)
+
+    if env.nil?
+      raise Puppet::Network::HTTP::Error::HTTPNotFoundError.new("#{env_name} is not a known environment", Puppet::Network::HTTP::Issues::RESOURCE_NOT_FOUND)
+    end
+
+    catalog = Puppet::Parser::EnvironmentCompiler.compile(env).to_resource
+
+    env_graph = {:environment => env.name, :applications => {}}
+    applications = catalog.resources.select do |res|
+      type = res.resource_type
+      type.is_a?(Puppet::Resource::Type) && type.application?
+    end
+    applications.each do |app|
+      app_components = {}
+      # Turn the 'nodes' hash into a map component ref => node name
+      node_mapping = app['nodes'].map do |k,v|
+        k.type == "Node" ? [k, v] : [v, k]
+      end.inject({}) do |map, (node, comp)|
+        map[comp.ref].nil? or raise Puppet::ParseError, "Application #{app} maps component #{comp} to mutiple nodes"
+        map[comp.ref] = node.title
+        map
+      end
+
+      catalog.direct_dependents_of(app).each do |comp|
+        mapped_node = node_mapping[comp.ref]
+        mapped_node or raise Puppet::ParseError, "Component #{comp} is not mapped to any node"
+        app_components[comp.ref] = {
+          :produces => comp.export.map(&:ref),
+          :consumes => prerequisites(comp).map(&:ref),
+          :node => mapped_node
+        }
+      end
+      env_graph[:applications][app.ref] = app_components
+    end
+    response.respond_with(200, "application/json", JSON.dump(env_graph))
+  end
+
+  private
+
+  # Find all the prerequisites of component +comp+. They are all the
+  # capability resources that +comp+ depends on; this includes resources
+  # that +comp+ consumes but also resources it merely requires
+  def prerequisites(comp)
+    params = Puppet::Type.relationship_params.select { |p| p.direction == :in }.map(&:name)
+    params.map { |rel| comp[rel] }.flatten.compact.select do |rel|
+      rel.resource_type and rel.resource_type.is_capability?
+    end
+  end
+end

--- a/lib/puppet/parser/ast/pops_bridge.rb
+++ b/lib/puppet/parser/ast/pops_bridge.rb
@@ -99,6 +99,8 @@ class Puppet::Parser::AST::PopsBridge
           instantiate_FunctionDefinition(d, modname)
           # The 3x logic calling this will not know what to do with the result, it is compacted away at the end
           next
+        when Puppet::Pops::Model::Application
+          instantiate_ApplicationDefinition(d, modname)
         else
           raise Puppet::ParseError, "Internal Error: Unknown type of definition - got '#{d.class}'"
         end
@@ -210,6 +212,11 @@ class Puppet::Parser::AST::PopsBridge
         raise Puppet::ParseError, "Internal Error: capability mapping is neither a 'produces' nor 'consumes', but a #{o.kind}"
       end
       nil
+    end
+
+    def instantiate_ApplicationDefinition(o, modname)
+      args = args_from_definition(o, modname)
+      Puppet::Resource::Type.new(:application, o.name, @context.merge(args))
     end
 
     def instantiate_NodeDefinition(o, modname)

--- a/lib/puppet/parser/compiler.rb
+++ b/lib/puppet/parser/compiler.rb
@@ -82,6 +82,12 @@ class Puppet::Parser::Compiler
   end
 
   def add_resource(scope, resource)
+    type = resource.resource_type
+    if type.is_a?(Puppet::Resource::Type) && type.application?
+      @applications << resource
+      return
+    end
+
     @resources << resource
 
     # Note that this will fail if the resource is not unique.
@@ -233,6 +239,8 @@ class Puppet::Parser::Compiler
 
   def initialize(node, options = {})
     @node = node
+    # Array of resources representing all application instances we've found
+    @applications = []
     set_options(options)
     initvars
   end

--- a/lib/puppet/parser/environment_compiler.rb
+++ b/lib/puppet/parser/environment_compiler.rb
@@ -1,0 +1,85 @@
+require 'puppet/parser/compiler'
+
+class Puppet::Parser::EnvironmentCompiler < Puppet::Parser::Compiler
+  def self.compile(env)
+    $env_module_directories = nil
+    env.check_for_reparse
+
+    node = Puppet::Node.new(env)
+    node.environment = env
+    new(node).compile
+  rescue => detail
+    message = "#{detail} in environment #{env.name}"
+    Puppet.log_exception(detail, message)
+    raise Puppet::Error, message, detail.backtrace
+  end
+
+  def compile
+    Puppet.override(@context_overrides, "For compiling environment #{environment.name}") do
+      @catalog.environment_instance = environment
+
+      Puppet::Util::Profiler.profile("Compile: Created settings scope", [:compiler, :create_settings_scope]) { create_settings_scope }
+
+      activate_binder
+
+      Puppet::Util::Profiler.profile("Compile: Evaluated main", [:compiler, :evaluate_main]) { evaluate_main }
+
+      Puppet::Util::Profiler.profile("Compile: Evaluated application instances", [:compiler, :evaluate_applications]) { evaluate_applications }
+
+      Puppet::Util::Profiler.profile("Compile: Finished catalog", [:compiler, :finish_catalog]) { finish }
+
+      fail_on_unevaluated
+
+      if block_given?
+        yield @catalog
+      else
+        @catalog
+      end
+    end
+  end
+
+  def add_resource(scope, resource)
+    type = resource.resource_type
+    # At topscope, only applications and Class[main] are allowed. Elsewhere,
+    # only components and capabilities are allowed.
+    if scope == @topscope
+      if ! (type.is_a?(Puppet::Resource::Type) && type.application?) && resource != @main_resource
+        raise ArgumentError, "Only applications are allowed at topscope, not #{resource.ref}"
+      end
+    else
+      unless (resource.is_application_component? || resource.is_capability?)
+        raise ArgumentError, "Only components are allowed inside applications, not #{resource.ref}"
+      end
+    end
+
+    @resources << resource
+
+    # Note that this will fail if the resource is not unique.
+    @catalog.add_resource(resource)
+
+    if not resource.class? and resource[:stage]
+      raise ArgumentError, "Only classes can set 'stage'; normal resources like #{resource} cannot change run stage"
+    end
+
+    # Stages should not be inside of classes.  They are always a
+    # top-level container, regardless of where they appear in the
+    # manifest.
+    return if resource.stage?
+
+    # This adds a resource to the class it lexically appears in in the
+    # manifest.
+    unless resource.class?
+      return @catalog.add_edge(scope.resource, resource)
+    end
+  end
+
+  def evaluate_applications
+    exceptwrap do
+      resources.select { |resource| type = resource.resource_type; type.is_a?(Puppet::Resource::Type) && type.application? }.each do |resource|
+        Puppet::Util::Profiler.profile("Evaluated resource #{resource}", [:compiler, :evaluate_resource, resource]) do
+          resource.evaluate
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet/pops/parser/egrammar.ra
+++ b/lib/puppet/pops/parser/egrammar.ra
@@ -497,7 +497,7 @@ definition_expression
 #---APPLICATION
 application_expression
   : APPLICATION classname parameter_list LBRACE opt_statements RBRACE {
-    result = Factory.APPLICATION(classname(val[1][:value]), val[2], val[4])
+    result = add_definition(Factory.APPLICATION(classname(val[1][:value]), val[2], val[4]))
     loc result, val[0], val[5]
   }
 

--- a/lib/puppet/pops/parser/eparser.rb
+++ b/lib/puppet/pops/parser/eparser.rb
@@ -2272,7 +2272,7 @@ module_eval(<<'.,.,', 'egrammar.ra', 488)
 
 module_eval(<<'.,.,', 'egrammar.ra', 499)
   def _reduce_138(val, _values, result)
-        result = Factory.APPLICATION(classname(val[1][:value]), val[2], val[4])
+        result = add_definition(Factory.APPLICATION(classname(val[1][:value]), val[2], val[4]))
     loc result, val[0], val[5]
   
     result

--- a/lib/puppet/resource.rb
+++ b/lib/puppet/resource.rb
@@ -304,7 +304,7 @@ class Puppet::Resource
     when "Class"; environment.known_resource_types.hostclass(title == :main ? "" : title)
     when "Node"; environment.known_resource_types.node(title)
     else
-      Puppet::Type.type(type) || environment.known_resource_types.definition(type)
+      Puppet::Type.type(type) || environment.known_resource_types.definition(type) || environment.known_resource_types.application(type)
     end
   end
 

--- a/lib/puppet/resource/type.rb
+++ b/lib/puppet/resource/type.rb
@@ -16,13 +16,14 @@ class Puppet::Resource::Type
   include Puppet::Util::Warnings
   include Puppet::Util::Errors
 
-  RESOURCE_KINDS = [:hostclass, :node, :definition]
+  RESOURCE_KINDS = [:hostclass, :node, :definition, :application]
 
   # Map the names used in our documentation to the names used internally
   RESOURCE_KINDS_TO_EXTERNAL_NAMES = {
       :hostclass => "class",
       :node => "node",
       :definition => "defined_type",
+      :application => "application"
   }
   RESOURCE_EXTERNAL_NAMES_TO_KINDS = RESOURCE_KINDS_TO_EXTERNAL_NAMES.invert
 
@@ -355,6 +356,7 @@ class Puppet::Resource::Type
     param = param.to_s
 
     return true if param == "name"
+    return true if param == "nodes" && application?
     return true if Puppet::Type.metaparam?(param)
     return false unless defined?(@arguments)
     return(arguments.include?(param) ? true : false)

--- a/lib/puppet/type/http.rb
+++ b/lib/puppet/type/http.rb
@@ -1,0 +1,8 @@
+Puppet::Type.newtype :http, :is_capability => true do
+  newparam :name
+  newparam :scheme
+  newparam :host
+  newparam :port
+  newparam :user
+  newparam :password
+end

--- a/lib/puppet/type/sql.rb
+++ b/lib/puppet/type/sql.rb
@@ -1,0 +1,8 @@
+Puppet::Type.newtype :sql, :is_capability => true do
+  newparam :name
+  newparam :host
+  newparam :port
+  newparam :user
+  newparam :password
+  newparam :database
+end


### PR DESCRIPTION
These patches do three things:

* recognize applications as a new kind of known resource type
* make sure that components mapped to a node wind up in that node's catalog
* add an environment compiler

These patches need to be applied on top of those for PUP-5045